### PR TITLE
Defined correct pullup_resistor for thermistors

### DIFF
--- a/docs/ProductDoc/MainBoard/fly-e3/fly-e3-pro/cfg.mdx
+++ b/docs/ProductDoc/MainBoard/fly-e3/fly-e3-pro/cfg.mdx
@@ -62,6 +62,7 @@ sidebar_label: Klipper参考配置
     heater_pin: PA5
     sensor_pin: PA4
     sensor_type: EPCOS 100K B57560G104F
+    pullup_resistor: 2200
     control: pid
     pid_Kp: 22.2
     pid_Ki: 1.08
@@ -90,6 +91,7 @@ sidebar_label: Klipper参考配置
     [heater_bed]
     heater_pin: PA0
     sensor_pin: PA3
+    pullup_resistor: 2200
     sensor_type: ATC Semitec 104GT-2
     control: watermark
     min_temp: 0


### PR DESCRIPTION
Klipper uses pullup_resistor: 4700 as default, but this board uses pullup_resistor: 2200. I have added the definition for this parameter so that it is reading the correct temperature.